### PR TITLE
[Add] Allow generation of Ref for invoice object

### DIFF
--- a/quickbooks/objects/invoice.py
+++ b/quickbooks/objects/invoice.py
@@ -104,3 +104,12 @@ class Invoice(DeleteMixin, QuickbooksPdfDownloadable, QuickbooksManagedObject, Q
             return True
 
         return False
+
+    def to_ref(self):
+        ref = Ref()
+
+        ref.name = self.DocNumber
+        ref.type = self.qbo_object_name
+        ref.value = self.Id
+
+        return ref

--- a/tests/unit/objects/test_invoice.py
+++ b/tests/unit/objects/test_invoice.py
@@ -39,6 +39,17 @@ class InvoiceTests(unittest.TestCase):
 
         self.assertTrue(result)
 
+    def test_to_ref(self):
+        invoice = Invoice()
+        invoice.DocNumber = 1
+        invoice.Id = 2
+
+        ref = invoice.to_ref()
+        self.assertIsInstance(ref, Ref)
+        self.assertEquals(ref.type, "Invoice")
+        self.assertEquals(ref.name, 1)  # should be DocNumber
+        self.assertEquals(ref.value, 2)  # should be Id
+
 
 class DeliveryInfoTests(unittest.TestCase):
     def test_init(self):


### PR DESCRIPTION
This will allow generation of ref objects for the invoice class. 

```
invoice = Invoice()
attachment = Attachable()  # object to create an attachment on quickbooks

attachable_ref = AttachableRef()  # object to attach references to the attachment object

attachable_ref.EntityRef = invoice.to_ref()
attachment.AttachableRef.append(attachable_ref)

attachment.FileName = "test.txt"
attachment.ContentType = "text/plain"
attachment._FilePath = f"/temp/dir/test.txt"  # full path to file
attachment.save(qb=quickbooks_client)
```