### PR TITLE
Remove DescriptionLine and used DescriptionOnlyLine instead

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -253,9 +253,12 @@ class QuickBooks(object):
         url = "{0}/company/{1}/{2}/{3}/".format(self.api_url, self.company_id, qbbo.lower(), pk)
         result = self.get(url, {})
 
-        return result
-
-    def handle_exceptions(self, results):
+    @staticmethod
+    def handle_exceptions(results):
+        """
+        Error codes with description in documentation:
+        https://developer.intuit.com/app/developer/qbo/docs/develop/troubleshooting/error-codes#id1
+        """
         # Needs to handle multiple errors
         for error in results["Error"]:
 
@@ -269,17 +272,17 @@ class QuickBooks(object):
             if "code" in error:
                 code = int(error["code"])
 
-            if code > 0 and code <= 499:
+            if 0 < code <= 499:
                 raise exceptions.AuthorizationException(message, code, detail)
-            elif code >= 500 and code <= 599:
+            elif 500 <= code <= 599:
                 raise exceptions.UnsupportedException(message, code, detail)
-            elif code >= 600 and code <= 1999:
+            elif 600 <= code <= 1999:
                 if code == 610:
                     raise exceptions.ObjectNotFoundException(message, code, detail)
                 raise exceptions.GeneralException(message, code, detail)
-            elif code >= 2000 and code <= 4999:
+            elif 2000 <= code <= 4999:
                 raise exceptions.ValidationException(message, code, detail)
-            elif code >= 10000:
+            elif 10000 <= code:
                 raise exceptions.SevereException(message, code, detail)
             else:
                 raise exceptions.QuickbooksException(message, code, detail)

--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -253,6 +253,8 @@ class QuickBooks(object):
         url = "{0}/company/{1}/{2}/{3}/".format(self.api_url, self.company_id, qbbo.lower(), pk)
         result = self.get(url, {})
 
+        return result
+
     @staticmethod
     def handle_exceptions(results):
         """

--- a/quickbooks/objects/__init__.py
+++ b/quickbooks/objects/__init__.py
@@ -21,9 +21,9 @@ from .deposit import (
 )
 from .detailline import (
     DetailLine, DiscountOverride, DiscountLineDetail, DiscountLine,
-    SubtotalLineDetail, SubtotalLine, DescriptionLineDetail, DescriptionLine,
+    SubtotalLineDetail, SubtotalLine, DescriptionLineDetail, DescriptionOnlyLine,
     SalesItemLineDetail, SalesItemLine, GroupLineDetail, GroupLine,
-    DescriptionOnlyLine, AccountBasedExpenseLineDetail, AccountBasedExpenseLine,
+    AccountBasedExpenseLineDetail, AccountBasedExpenseLine,
     TDSLineDetail, TDSLine, ItemBasedExpenseLineDetail, ItemBasedExpenseLine,
 
 )

--- a/quickbooks/objects/creditmemo.py
+++ b/quickbooks/objects/creditmemo.py
@@ -1,6 +1,6 @@
 from six import python_2_unicode_compatible
 
-from quickbooks.objects.detailline import SalesItemLine, SubtotalLine, DiscountLine, DescriptionLine, DetailLine
+from quickbooks.objects.detailline import SalesItemLine, SubtotalLine, DiscountLine, DescriptionOnlyLine, DetailLine
 from .base import Address, EmailAddress, Ref, CustomField, CustomerMemo, QuickbooksManagedObject, \
     LinkedTxnMixin, QuickbooksTransactionEntity
 from .tax import TxnTaxDetail
@@ -38,7 +38,7 @@ class CreditMemo(DeleteMixin, QuickbooksTransactionEntity, QuickbooksManagedObje
         "SalesItemLineDetail": SalesItemLine,
         "SubTotalLineDetail": SubtotalLine,
         "DiscountLineDetail": DiscountLine,
-        "DescriptionLineDetail": DescriptionLine
+        "DescriptionLineDetail": DescriptionOnlyLine
     }
 
     qbo_object_name = "CreditMemo"

--- a/quickbooks/objects/detailline.py
+++ b/quickbooks/objects/detailline.py
@@ -100,17 +100,6 @@ class DescriptionLineDetail(QuickbooksBaseObject):
         self.TaxCodeRef = None
 
 
-class DescriptionLine(DetailLine):
-    class_dict = {
-        "DescriptionLineDetail": DescriptionLineDetail
-    }
-
-    def __init__(self):
-        super(DescriptionLine, self).__init__()
-        self.DetailType = "DescriptionOnly"
-        self.DescriptionLineDetail = None
-
-
 @python_2_unicode_compatible
 class SalesItemLineDetail(QuickbooksBaseObject):
     class_dict = {

--- a/quickbooks/objects/estimate.py
+++ b/quickbooks/objects/estimate.py
@@ -2,7 +2,7 @@ from six import python_2_unicode_compatible
 from .base import CustomField, Ref, CustomerMemo, Address, EmailAddress, QuickbooksManagedObject, \
     LinkedTxnMixin, QuickbooksTransactionEntity, LinkedTxn
 from .tax import TxnTaxDetail
-from .detailline import DetailLine, SalesItemLine, GroupLine, DescriptionLine, DiscountLine, SubtotalLine
+from .detailline import DetailLine, SalesItemLine, GroupLine, DescriptionOnlyLine, DiscountLine, SubtotalLine
 from ..mixins import QuickbooksPdfDownloadable, DeleteMixin, SendMixin
 
 
@@ -41,7 +41,7 @@ class Estimate(DeleteMixin,
     detail_dict = {
         "SalesItemLineDetail": SalesItemLine,
         "GroupLineDetail": GroupLine,
-        "DescriptionOnly": DescriptionLine,
+        "DescriptionOnly": DescriptionOnlyLine,
         "DiscountLineDetail": DiscountLine,
         "SubTotalLineDetail": SubtotalLine,
     }

--- a/tests/unit/objects/test_detailline.py
+++ b/tests/unit/objects/test_detailline.py
@@ -1,7 +1,7 @@
 import unittest
 
 from quickbooks.objects.detailline import SalesItemLineDetail, DiscountOverride, DetailLine, SubtotalLineDetail, \
-    DiscountLineDetail, SubtotalLine, DescriptionLineDetail, DescriptionLine, SalesItemLine, DiscountLine, GroupLine, \
+    DiscountLineDetail, SubtotalLine, DescriptionLineDetail, SalesItemLine, DiscountLine, GroupLine, \
     AccountBasedExpenseLineDetail, ItemBasedExpenseLineDetail, DescriptionOnlyLine, ItemBasedExpenseLine
 
 
@@ -62,14 +62,6 @@ class DescriptionLineDetailTest(unittest.TestCase):
 
         self.assertEquals(description_detail.ServiceDate, "")
         self.assertEquals(description_detail.TaxCodeRef, None)
-
-
-class DescriptionLineTest(unittest.TestCase):
-    def test_init(self):
-        line = DescriptionLine()
-
-        self.assertEquals(line.DetailType, "DescriptionOnly")
-        self.assertEquals(line.DescriptionLineDetail, None)
 
 
 class SalesItemLineTest(unittest.TestCase):


### PR DESCRIPTION
I haven't found any use of `DescriptionLine` in documentation. And in places where it was used in library we should use `DescriptionOnlyLine`. So I replaced it.

Also did small refactoring improvement in `QuickBooks.client.QuickBooks.handle_exceptions`