### PR TITLE
Added Refresh Token to Client Instance

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -77,7 +77,8 @@ class QuickBooks(object):
             else:
                 instance.sandbox = False
 
-            instance._start_session()
+            refresh_token = instance._start_session()
+            instance.refresh_token = refresh_token
 
         if 'company_id' in kwargs:
             instance.company_id = kwargs['company_id']
@@ -99,6 +100,7 @@ class QuickBooks(object):
             client_secret=self.auth_client.client_secret,
             access_token=self.auth_client.access_token,
         )
+        return self.auth_client.refresh_token
 
     @classmethod
     def get_instance(cls):


### PR DESCRIPTION
According to the QuickBooks documentation, the refresh() function call might return a new refresh token and as a best practice, we need to use that token for future requests.
I added the refresh token to the client instance so that on creation of a client, the user gets back a possibly new refresh code that they can use to create other clients.
The current implementation would require users to redo the oauth2 process every 100 days while the new implementation will only require it one time upon server start
This change will not break existing applications that use this library and will improve quality of life for any new applications built using this library

Reference: [https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0#understand-token-expiration](url)