### PR TITLE
Expand capabilities of build_where_clause

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,6 +17,28 @@ class UtilsTests(unittest.TestCase):
         self.assertTrue("field1 = 'Test 1'" in where_clause)
         self.assertTrue("field2 = 'Someone\\\'s Company'" in where_clause)
 
+    def test_build_where_clause_operators(self):
+        where_clause = utils.build_where_clause(field1__gt=10,
+                                                field2__gte=12,
+                                                field3__lt="it's",
+                                                field4__lte='16',
+                                                field5__like="mike")
+
+        self.assertTrue("field1 > 10" in where_clause)
+        self.assertTrue("field2 >= 12" in where_clause)
+        self.assertTrue("field3 < 'it\\\'s'" in where_clause)
+        self.assertTrue("field4 <= '16'" in where_clause)
+        self.assertTrue("field5 LIKE 'mike'" in where_clause)
+
+    def test_build_where_clause_in(self):
+        where_clause = utils.build_where_clause(field1__in=["hakuna", "matata"],
+                                                field2__in=[1, 2],
+                                                field3__in=["Fred's", "Bill's"])
+
+        self.assertTrue("field1 IN ('hakuna', 'matata')" in where_clause)
+        self.assertTrue("field2 IN ('1', '2')" in where_clause)
+        self.assertTrue("field3 IN ('Fred\\\'s', 'Bill\\\'s')" in where_clause)
+
     def test_build_choose_clause_integers(self):
         where_clause = utils.build_choose_clause(choices=[1, 2],
                                                  field="field1")


### PR DESCRIPTION
Adds the features requested in https://github.com/ej2/python-quickbooks/issues/237 as well as some tests.

This _may_ make the `build_choose_clause` redundant as well.

I'm not sure what your requirements are around python2 - some of this may not be valid python 2.