### PR TITLE
Thread through a `request_id` for create, update, and delete requests

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -164,12 +164,15 @@ class QuickBooks(object):
         return result
 
     def make_request(self, request_type, url, request_body=None, content_type='application/json',
-                     params=None, file_path=None):
+                     params=None, file_path=None, request_id=None):
         if not params:
             params = {}
 
         if self.minorversion:
             params['minorversion'] = self.minorversion
+        
+        if request_id:
+            params['requestid'] = request_id
 
         if not request_body:
             request_body = {}
@@ -291,11 +294,11 @@ class QuickBooks(object):
             else:
                 raise exceptions.QuickbooksException(message, code, detail)
 
-    def create_object(self, qbbo, request_body, _file_path=None):
+    def create_object(self, qbbo, request_body, _file_path=None, request_id=None):
         self.isvalid_object_name(qbbo)
 
         url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id, qbbo.lower())
-        results = self.post(url, request_body, file_path=_file_path)
+        results = self.post(url, request_body, file_path=_file_path, request_id=request_id)
 
         return results
 
@@ -311,15 +314,15 @@ class QuickBooks(object):
 
         return True
 
-    def update_object(self, qbbo, request_body, _file_path=None):
+    def update_object(self, qbbo, request_body, _file_path=None, request_id=None):
         url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id,  qbbo.lower())
-        result = self.post(url, request_body, file_path=_file_path)
+        result = self.post(url, request_body, file_path=_file_path, request_id=request_id)
 
         return result
 
-    def delete_object(self, qbbo, request_body, _file_path=None):
+    def delete_object(self, qbbo, request_body, _file_path=None, request_id=None):
         url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id, qbbo.lower())
-        result = self.post(url, request_body, params={'operation': 'delete'}, file_path=_file_path)
+        result = self.post(url, request_body, params={'operation': 'delete'}, file_path=_file_path, request_id=request_id)
 
         return result
 

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -1,5 +1,4 @@
 from future.moves.urllib.parse import quote
-from requests.api import request
 
 try: import simplejson as json
 except ImportError: import json

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -1,4 +1,5 @@
 from future.moves.urllib.parse import quote
+from requests.api import request
 
 try: import simplejson as json
 except ImportError: import json
@@ -148,14 +149,14 @@ class UpdateMixin(object):
     qbo_object_name = ""
     qbo_json_object_name = ""
 
-    def save(self, qb=None):
+    def save(self, qb=None, request_id=None):
         if not qb:
             qb = QuickBooks()
 
         if self.Id and int(self.Id) > 0:
-            json_data = qb.update_object(self.qbo_object_name, self.to_json())
+            json_data = qb.update_object(self.qbo_object_name, self.to_json(), request_id=request_id)
         else:
-            json_data = qb.create_object(self.qbo_object_name, self.to_json())
+            json_data = qb.create_object(self.qbo_object_name, self.to_json(), request_id=request_id)
 
         if self.qbo_json_object_name != '':
             obj = type(self).from_json(json_data[self.qbo_json_object_name])
@@ -170,11 +171,11 @@ class UpdateNoIdMixin(object):
     qbo_object_name = ""
     qbo_json_object_name = ""
 
-    def save(self, qb=None):
+    def save(self, qb=None, request_id=None):
         if not qb:
             qb = QuickBooks()
 
-        json_data = qb.update_object(self.qbo_object_name, self.to_json())
+        json_data = qb.update_object(self.qbo_object_name, self.to_json(), request_id=request_id)
         obj = type(self).from_json(json_data[self.qbo_object_name])
         return obj
 
@@ -182,7 +183,7 @@ class UpdateNoIdMixin(object):
 class DeleteMixin(object):
     qbo_object_name = ""
 
-    def delete(self, qb=None):
+    def delete(self, qb=None, request_id=None):
         if not qb:
             qb = QuickBooks()
 
@@ -193,7 +194,7 @@ class DeleteMixin(object):
             'Id': self.Id,
             'SyncToken': self.SyncToken,
         }
-        return qb.delete_object(self.qbo_object_name, json.dumps(data))
+        return qb.delete_object(self.qbo_object_name, json.dumps(data), request_id=request_id)
 
 
 class ListMixin(object):

--- a/tests/integration/test_invoice.py
+++ b/tests/integration/test_invoice.py
@@ -4,10 +4,11 @@ from quickbooks.objects.detailline import SalesItemLine, SalesItemLineDetail
 from quickbooks.objects.invoice import Invoice
 from quickbooks.objects.item import Item
 from tests.integration.test_base import QuickbooksTestCase
-
+import uuid
 
 class InvoiceTest(QuickbooksTestCase):
-    def test_create(self):
+
+    def create_invoice(self, request_id=None):
         invoice = Invoice()
 
         line = SalesItemLine()
@@ -25,35 +26,28 @@ class InvoiceTest(QuickbooksTestCase):
 
         invoice.CustomerMemo = CustomerMemo()
         invoice.CustomerMemo.value = "Customer Memo"
-        invoice.save(qb=self.qb_client)
+        invoice.save(qb=self.qb_client, request_id=request_id)
 
+    def test_create(self):
+        invoice = self.create_invoice()
         query_invoice = Invoice.get(invoice.Id, qb=self.qb_client)
 
         self.assertEquals(query_invoice.CustomerRef.name, customer.DisplayName)
         self.assertEquals(query_invoice.CustomerMemo.value, "Customer Memo")
         self.assertEquals(query_invoice.Line[0].Description, "description")
         self.assertEquals(query_invoice.Line[0].Amount, 100.0)
+    
+    def test_create_idempotence(self):
+        sample_request_id = str(uuid.uuid4())
+        invoice = self.create_invoice(request_id=sample_request_id)
+        duplicate_invoice = self.create_invoice(request_id=sample_request_id)
+
+        # Assert that both returned invoices have the same id
+        self.assertEquals(invoice.Id, duplicate_invoice.Id)
 
     def test_delete(self):
         # First create an invoice
-        invoice = Invoice()
-
-        line = SalesItemLine()
-        line.LineNum = 1
-        line.Description = "description"
-        line.Amount = 100
-        line.SalesItemLineDetail = SalesItemLineDetail()
-        item = Item.all(max_results=1, qb=self.qb_client)[0]
-
-        line.SalesItemLineDetail.ItemRef = item.to_ref()
-        invoice.Line.append(line)
-
-        customer = Customer.all(max_results=1, qb=self.qb_client)[0]
-        invoice.CustomerRef = customer.to_ref()
-
-        invoice.CustomerMemo = CustomerMemo()
-        invoice.CustomerMemo.value = "Customer Memo"
-        invoice.save(qb=self.qb_client)
+        invoice = self.create_invoice()
 
         # Then delete
         invoice_id = invoice.Id

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -124,7 +124,7 @@ class ClientTest(QuickbooksUnitTestCase):
         qb_client.update_object("Customer", "request_body", request_id="123")
 
         url = "https://sandbox-quickbooks.api.intuit.com/v3/company/1234/customer"
-        make_req.assert_called_with("POST", url, request_id="123")
+        make_req.assert_called_with("POST", url, "request_body", file_path = None, request_id="123")
 
     @patch('quickbooks.client.QuickBooks.get')
     def test_get_current_user(self, get):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -117,6 +117,15 @@ class ClientTest(QuickbooksUnitTestCase):
 
         self.assertTrue(post.called)
 
+    @patch('quickbooks.client.QuickBooks.make_request')
+    def test_update_object_with_request_id(self, make_req):
+        qb_client = client.QuickBooks()
+        qb_client.company_id = "1234"
+        qb_client.update_object("Customer", "request_body", request_id="123")
+
+        url = "https://sandbox-quickbooks.api.intuit.com/v3/company/1234/customer"
+        make_req.assert_called_with("POST", url, request_id="123")
+
     @patch('quickbooks.client.QuickBooks.get')
     def test_get_current_user(self, get):
         qb_client = client.QuickBooks()
@@ -162,6 +171,7 @@ class ClientTest(QuickbooksUnitTestCase):
         process_request.assert_called_with(
                 "GET", url, data={},
                 headers={'Content-Type': 'application/json', 'Accept': 'application/json', 'User-Agent': 'python-quickbooks V3 library'}, params={})
+
 
     def test_handle_exceptions(self):
         qb_client = client.QuickBooks()

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -227,7 +227,7 @@ class UpdateMixinTest(QuickbooksUnitTestCase):
     def test_save_create(self, create_object):
         department = Department()
         department.save(qb=self.qb_client)
-        create_object.assert_called_once_with("Department", department.to_json())
+        create_object.assert_called_once_with("Department", department.to_json(), request_id=None)
 
     def test_save_create_with_qb(self):
         with patch.object(self.qb_client, 'create_object') as create_object:
@@ -242,7 +242,7 @@ class UpdateMixinTest(QuickbooksUnitTestCase):
         json = department.to_json()
 
         department.save(qb=self.qb_client)
-        update_object.assert_called_once_with("Department", json)
+        update_object.assert_called_once_with("Department", json, request_id=None)
 
     def test_save_update_with_qb(self):
         with patch.object(self.qb_client, 'update_object') as update_object:


### PR DESCRIPTION
The requestid parameter is used to implement idempotency for the Quickbooks API and is documented on the [REST API format page](https://developer.intuit.com/app/developer/qbo/docs/learn/rest-api-features). This PR adds the ability to specify this parameter in the mixin when calling update actions. 

I've also added a unit test and an integration test (using the example of invoice creation) that corresponds to this new behavior.

See also https://github.com/ej2/python-quickbooks/issues/255