### PR TITLE
Add ClassRef Initialization for AccountBasedExpenseDetailLine

### DIFF
--- a/quickbooks/objects/detailline.py
+++ b/quickbooks/objects/detailline.py
@@ -183,6 +183,7 @@ class AccountBasedExpenseLineDetail(QuickbooksBaseObject):
         self.CustomerRef = None
         self.AccountRef = None
         self.TaxCodeRef = None
+        self.ClassRef = None
 
     def __str__(self):
         return self.BillableStatus


### PR DESCRIPTION
This one bit me today. I saw it in the issues, so here's a PR. If you ever want help maintaining this library (now that you're at FortAwesome), I'd be happy to help.

I'm the CTO at [uncat.com](https://uncat.com), which is probably one of the few QuickBooks Online/Desktop apps out there using Python/Django for as many customers as we have. :) I love this library!