### PR TITLE
chore(deps): remove unused pycparser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'simplejson>=3.17.0',
         'six>=1.14.0',
         'python-dateutil',
-        'pycparser==2.18'
     ],
 
     classifiers=[


### PR DESCRIPTION
The pin to `pycparser==2.18` was brought about when the package was still supporting Python 2.6.
See https://github.com/ej2/python-quickbooks/pull/126

Python 2.6 (and 2.7) support were dropped in versions 0.7.5 and 0.8.1 respectively. (from `CHANGELOG.rst`)

The `authlib` library that depended on `pycparser` was removed in version 0.9.1
See https://github.com/ej2/python-quickbooks/pull/258

We can now safely remove `pycparser` from the project scope,
and thus any other dependencies that rely on `pycparser`
can now advance past version 2.18 without conflict.