### PR TITLE
Add LinkedTxnMixin Payments

### DIFF
--- a/quickbooks/objects/payment.py
+++ b/quickbooks/objects/payment.py
@@ -1,6 +1,6 @@
 from six import python_2_unicode_compatible
 from .base import QuickbooksBaseObject, Ref, LinkedTxn, \
-    QuickbooksManagedObject, QuickbooksTransactionEntity \
+    QuickbooksManagedObject, QuickbooksTransactionEntity, \
     LinkedTxnMixin
 from ..client import QuickBooks
 from .creditcardpayment import CreditCardPayment

--- a/quickbooks/objects/payment.py
+++ b/quickbooks/objects/payment.py
@@ -1,6 +1,7 @@
 from six import python_2_unicode_compatible
 from .base import QuickbooksBaseObject, Ref, LinkedTxn, \
-    QuickbooksManagedObject, QuickbooksTransactionEntity
+    QuickbooksManagedObject, QuickbooksTransactionEntity \
+    LinkedTxnMixin
 from ..client import QuickBooks
 from .creditcardpayment import CreditCardPayment
 from ..mixins import DeleteMixin
@@ -23,7 +24,7 @@ class PaymentLine(QuickbooksBaseObject):
 
 
 @python_2_unicode_compatible
-class Payment(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity):
+class Payment(DeleteMixin, QuickbooksManagedObject, QuickbooksTransactionEntity, LinkedTxnMixin):
     """
     QBO definition: A Payment entity records a payment in QuickBooks. The payment can be
     applied for a particular customer against multiple Invoices and Credit Memos. It can also


### PR DESCRIPTION
This is missing and needed to add it for PaymentLine:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/15338540/182589971-e32a6cb1-f903-46d6-bee6-92721c936448.png">

Fix: https://github.com/ej2/python-quickbooks/issues/260