### PR TITLE
Added name/value paramter tuple to .save args

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -305,10 +305,16 @@ class QuickBooks(object):
             else:
                 raise exceptions.QuickbooksException(message, code, detail)
 
-    def create_object(self, qbbo, request_body, _file_path=None, request_id=None):
+    def create_object(self, qbbo, request_body, _file_path=None, request_id=None, parameter_tuple=None):
         self.isvalid_object_name(qbbo)
 
-        url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id, qbbo.lower())
+        if parameter_tuple is None:
+            url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id, qbbo.lower())
+        else:
+            name = parameter_tuple[0]
+            value = parameter_tuple[1]
+            url = "{0}/company/{1}/{2}?{3}={4}".format(self.api_url, self.company_id, qbbo.lower(), name, value)
+
         results = self.post(url, request_body, file_path=_file_path, request_id=request_id)
 
         return results
@@ -325,8 +331,14 @@ class QuickBooks(object):
 
         return True
 
-    def update_object(self, qbbo, request_body, _file_path=None, request_id=None):
-        url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id,  qbbo.lower())
+    def update_object(self, qbbo, request_body, _file_path=None, request_id=None, parameter_tuple = None):
+        if parameter_tuple is None:
+            url = "{0}/company/{1}/{2}".format(self.api_url, self.company_id, qbbo.lower())
+        else:
+            name = parameter_tuple[0]
+            value = parameter_tuple[1]
+            url = "{0}/company/{1}/{2}?{3}={4}".format(self.api_url, self.company_id, qbbo.lower(), name, value)
+
         result = self.post(url, request_body, file_path=_file_path, request_id=request_id)
 
         return result

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -148,14 +148,14 @@ class UpdateMixin(object):
     qbo_object_name = ""
     qbo_json_object_name = ""
 
-    def save(self, qb=None, request_id=None):
+    def save(self, qb=None, request_id=None, parameter_tuple=None):
         if not qb:
             qb = QuickBooks()
 
         if self.Id and int(self.Id) > 0:
-            json_data = qb.update_object(self.qbo_object_name, self.to_json(), request_id=request_id)
+            json_data = qb.update_object(self.qbo_object_name, self.to_json(), request_id=request_id, parameter_tuple=parameter_tuple)
         else:
-            json_data = qb.create_object(self.qbo_object_name, self.to_json(), request_id=request_id)
+            json_data = qb.create_object(self.qbo_object_name, self.to_json(), request_id=request_id, parameter_tuple=parameter_tuple)
 
         if self.qbo_json_object_name != '':
             obj = type(self).from_json(json_data[self.qbo_json_object_name])
@@ -170,11 +170,11 @@ class UpdateNoIdMixin(object):
     qbo_object_name = ""
     qbo_json_object_name = ""
 
-    def save(self, qb=None, request_id=None):
+    def save(self, qb=None, request_id=None, parameter_tuple=None):
         if not qb:
             qb = QuickBooks()
 
-        json_data = qb.update_object(self.qbo_object_name, self.to_json(), request_id=request_id)
+        json_data = qb.update_object(self.qbo_object_name, self.to_json(), request_id=request_id, parameter_tuple=parameter_tuple)
         obj = type(self).from_json(json_data[self.qbo_object_name])
         return obj
 


### PR DESCRIPTION
Ref https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchase

From there ... "If a duplicate DocNumber needs to be supplied, add the query parameter name/value pair, include=allowduplicatedocnum to the URI. Sort order is ASC by default."

This pull allows a name/value pair to be passed through from save() to where the URI is formatted.

e.g. purchase.save(qb=client, parameter_tuple = ('include', 'allowduplicatedocnum'))