### PR TITLE
Add support for RecurringTransaction

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -53,6 +53,7 @@ class QuickBooks(object):
         "Purchase", "PurchaseOrder", "RefundReceipt",
         "SalesReceipt", "TaxAgency", "TaxCode", "TaxService/Taxcode", "TaxRate", "Term",
         "TimeActivity", "Transfer", "Vendor", "VendorCredit", "CreditCardPayment",
+        "RecurringTransaction"
     ]
 
     __instance = None

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -196,6 +196,16 @@ class DeleteMixin(object):
         return qb.delete_object(self.qbo_object_name, json.dumps(data), request_id=request_id)
 
 
+class DeleteNoIdMixin(object):
+    qbo_object_name = ""
+
+    def delete(self, qb=None, request_id=None):
+        if not qb:
+            qb = QuickBooks()
+
+        return qb.delete_object(self.qbo_object_name, self.to_json(), request_id=request_id)
+
+
 class ListMixin(object):
     qbo_object_name = ""
     qbo_json_object_name = ""

--- a/quickbooks/objects/recurringtransaction.py
+++ b/quickbooks/objects/recurringtransaction.py
@@ -1,0 +1,132 @@
+from six import python_2_unicode_compatible
+
+from .bill import Bill
+from .creditmemo import CreditMemo
+from .deposit import Deposit
+from .estimate import Estimate
+from .invoice import Invoice
+from .journalentry import JournalEntry
+from .purchase import Purchase
+from .purchaseorder import PurchaseOrder
+from .refundreceipt import RefundReceipt
+from .salesreceipt import SalesReceipt
+from .transfer import Transfer
+from .vendorcredit import VendorCredit
+from .base import Ref, QuickbooksBaseObject
+from ..mixins import UpdateNoIdMixin, ListMixin, ReadMixin, DeleteNoIdMixin
+
+class ScheduleInfo(QuickbooksBaseObject):
+    def __init__(self):
+        super(ScheduleInfo, self).__init__()
+
+        self.StartDate = None
+        self.EndDate = None
+        self.DaysBefore = None
+        self.MaxOccurrences = None
+        
+        self.RemindDays = None
+        self.IntervalType = None
+        self.NumInterval = None
+        
+        self.DayOfMonth = None
+        self.DayOfWeek = None
+        self.MonthOfYear = None
+        self.WeekOfMonth = None
+        
+        self.NextDate = None
+        self.PreviousDate = None
+
+        
+class RecurringInfo(QuickbooksBaseObject):
+    class_dict = {
+        "ScheduleInfo": ScheduleInfo
+    }
+
+    qbo_object_name = "RecurringInfo"
+
+    def __init__(self):
+        super(RecurringInfo, self).__init__()
+
+        self.RecurType = "Automated"
+        self.Name = ""
+        self.Active = False
+
+
+class Recurring():    
+    class_dict = {
+        "RecurringInfo": RecurringInfo,
+        "RecurDataRef": Ref
+    }
+
+
+class RecurringBill(Bill):
+    class_dict = {**Bill.class_dict, **Recurring.class_dict}
+
+
+class RecurringPurchase(Purchase):
+    class_dict = {**Purchase.class_dict, **Recurring.class_dict}
+
+
+class RecurringCreditMemo(CreditMemo):
+    class_dict = {**CreditMemo.class_dict, **Recurring.class_dict}
+
+
+class RecurringDeposit(Deposit):
+    class_dict = {**Deposit.class_dict, **Recurring.class_dict}
+
+
+class RecurringEstimate(Estimate):
+    class_dict = {**Estimate.class_dict, **Recurring.class_dict}
+
+
+class RecurringInvoice(Invoice):
+    class_dict = {**Invoice.class_dict, **Recurring.class_dict}
+
+
+class RecurringJournalEntry(JournalEntry):
+    class_dict = {**JournalEntry.class_dict, **Recurring.class_dict}
+
+
+class RecurringRefundReceipt(RefundReceipt):
+    class_dict = {**RefundReceipt.class_dict, **Recurring.class_dict}
+
+
+class RecurringSalesReceipt(SalesReceipt):
+    class_dict = {**SalesReceipt.class_dict, **Recurring.class_dict}
+
+
+class RecurringTransfer(Transfer):
+    class_dict = {**Transfer.class_dict, **Recurring.class_dict}
+
+
+class RecurringVendorCredit(VendorCredit):
+    class_dict = {**VendorCredit.class_dict, **Recurring.class_dict}
+
+
+class RecurringPurchaseOrder(PurchaseOrder):
+    class_dict = {**PurchaseOrder.class_dict, **Recurring.class_dict}
+
+
+@python_2_unicode_compatible
+class RecurringTransaction(QuickbooksBaseObject, ReadMixin, UpdateNoIdMixin, ListMixin, DeleteNoIdMixin):
+    """
+    QBO definition: A RecurringTransaction object refers to scheduling creation of transactions,
+    set up reminders and create transaction template for later use.
+    This feature is available in QuickBooks Essentials and Plus SKU.
+    """
+    class_dict = {
+        "Bill": RecurringBill,
+        "Purchase": RecurringPurchase,
+        "CreditMemo": RecurringCreditMemo,
+        "Deposit": RecurringDeposit,
+        "Estimate": RecurringEstimate,
+        "Invoice": RecurringInvoice,
+        "JournalEntry": RecurringJournalEntry,
+        "RefundReceipt": RecurringRefundReceipt,
+        "SalesReceipt": RecurringSalesReceipt,
+        "Transfer": RecurringTransfer,
+        "VendorCredit": RecurringVendorCredit,
+        "PurchaseOrder": RecurringPurchaseOrder
+    }
+
+    qbo_object_name = "RecurringTransaction"

--- a/tests/integration/test_recurringtransaction.py
+++ b/tests/integration/test_recurringtransaction.py
@@ -1,0 +1,169 @@
+from datetime import datetime, timedelta
+from quickbooks.objects.base import Ref
+from quickbooks.objects.customer import Customer
+from quickbooks.objects.detailline import SalesItemLine, SalesItemLineDetail, AccountBasedExpenseLine, AccountBasedExpenseLineDetail
+from quickbooks.objects.recurringtransaction import RecurringTransaction, RecurringInfo, ScheduleInfo, RecurringInvoice, RecurringBill
+from quickbooks.objects.item import Item
+from quickbooks.objects.vendor import Vendor
+from tests.integration.test_base import QuickbooksTestCase
+
+class RecurringTransactionTest(QuickbooksTestCase):
+    def setUp(self):
+        super(RecurringTransactionTest, self).setUp()
+        self.now = datetime.now()
+
+    def create_recurring_invoice(self, t):
+        # Regular Invoice stuff except use a RecurringInvoice
+        line = SalesItemLine()
+        line.LineNum = 1
+        line.Description = "description"
+        line.Amount = 100
+        
+        line.SalesItemLineDetail = SalesItemLineDetail()        
+        item = Item.all(max_results=1, qb=self.qb_client)[0]
+        line.SalesItemLineDetail.ItemRef = item.to_ref()
+
+        invoice = RecurringInvoice()
+
+        invoice.Line.append(line)
+
+        customer = Customer.all(max_results=1, qb=self.qb_client)[0]
+        invoice.CustomerRef = customer.to_ref()
+
+        # Now the recurring bits
+        info = RecurringInfo()
+        info.Active = True
+        info.RecurType = "Automated"
+        info.Name = "Test Recurring Invoice {}".format(t.strftime('%d%H%M%S'))
+        
+        info.ScheduleInfo = ScheduleInfo()
+        info.ScheduleInfo.StartDate = t.strftime("%Y-%m-%d")
+        info.ScheduleInfo.MaxOccurrences = 6
+        info.ScheduleInfo.IntervalType = "Monthly"
+        info.ScheduleInfo.DayOfMonth = 1
+        info.ScheduleInfo.NumInterval = 1
+        invoice.RecurringInfo = info
+
+        rt = RecurringTransaction()
+        rt.Invoice = invoice
+
+        return rt.save(qb=self.qb_client)
+
+
+    def test_create_recurring_invoice(self):
+        actual_rt = self.create_recurring_invoice(self.now)
+
+        self.assertTrue(hasattr(actual_rt, "Invoice"))
+        self.assertEquals(actual_rt.Invoice.Line[0].Description, "description")
+        self.assertEquals(actual_rt.Invoice.Line[0].Amount, 100.0)
+        
+        actual_info = actual_rt.Invoice.RecurringInfo
+        self.assertEqual(actual_info.ScheduleInfo.MaxOccurrences, 6)
+        self.assertEqual(actual_info.ScheduleInfo.IntervalType, "Monthly")
+        self.assertEqual(actual_info.ScheduleInfo.DayOfMonth, 1)
+        self.assertEqual(actual_info.ScheduleInfo.NumInterval, 1)
+
+    
+    def test_create_recurring_bill(self):
+        bill = RecurringBill()
+
+        line = AccountBasedExpenseLine()
+        line.Amount = 500
+        line.DetailType = "AccountBasedExpenseLineDetail"
+
+        account_ref = Ref()
+        account_ref.type = "Account"
+        account_ref.value = 1
+        line.AccountBasedExpenseLineDetail = AccountBasedExpenseLineDetail()
+        line.AccountBasedExpenseLineDetail.AccountRef = account_ref
+        bill.Line.append(line)
+
+        vendor = Vendor.all(max_results=1, qb=self.qb_client)[0]
+        bill.VendorRef = vendor.to_ref()
+
+        recurring_info = RecurringInfo()
+        recurring_info.Active = True
+        recurring_info.RecurType = "Automated"
+        recurring_info.Name = "Test Recurring Bill {}".format(datetime.now().strftime('%d%H%M%S'))
+
+        recurring_info.ScheduleInfo = ScheduleInfo()
+        recurring_info.ScheduleInfo.StartDate = self.now.strftime("%Y-%m-%d")
+        
+        end_date = self.now + timedelta(weeks=12)
+        recurring_info.ScheduleInfo.EndDate = end_date.strftime("%Y-%m-%d")
+
+        recurring_info.ScheduleInfo.NumInterval = 1
+        recurring_info.ScheduleInfo.DaysBefore = 3
+        recurring_info.ScheduleInfo.IntervalType = "Weekly"
+        recurring_info.ScheduleInfo.DayOfWeek = "Friday"
+
+        bill.RecurringInfo = recurring_info
+
+        recurring_txn = RecurringTransaction()
+        recurring_txn.Bill = bill
+
+        saved = recurring_txn.save(qb=self.qb_client)
+
+        actual_rt = RecurringTransaction.get(saved.Bill.Id, qb=self.qb_client)
+        
+        self.assertTrue(hasattr(actual_rt, "Bill"))
+        actual_info = actual_rt.Bill.RecurringInfo
+        self.assertEqual(actual_info.ScheduleInfo.EndDate, end_date.strftime("%Y-%m-%d"))
+        self.assertEqual(actual_info.ScheduleInfo.IntervalType, "Weekly")
+        self.assertEqual(actual_info.ScheduleInfo.DayOfWeek, "Friday")
+        self.assertEqual(actual_info.ScheduleInfo.NumInterval, 1)
+
+    
+    def test_update_recurring_invoice(self):
+        saved = self.create_recurring_invoice(self.now + timedelta(seconds=+1)) # add a second to not conflict with the other test
+        recurring_txn = RecurringTransaction.get(saved.Invoice.Id, qb=self.qb_client)
+
+        recurring_txn.Invoice.RecurringInfo.ScheduleInfo.DayOfMonth = 15
+        recurring_txn.Invoice.Line[0].Amount = 250
+
+        # QBO api returns this to us as 0 but if you send it back you get an error
+        recurring_txn.Invoice.Deposit = None
+
+        recurring_txn.save(qb=self.qb_client)
+
+        actual = RecurringTransaction.get(saved.Invoice.Id, qb=self.qb_client)
+        self.assertEquals(actual.Invoice.RecurringInfo.ScheduleInfo.DayOfMonth, 15)
+        self.assertEquals(actual.Invoice.Line[0].Amount, 250)
+
+
+    def test_filter_by_type(self):
+        recurring_txns = RecurringTransaction.where("Type = 'Bill'", qb=self.qb_client)
+
+        for recurring_txn in recurring_txns:
+            self.assertTrue(hasattr(recurring_txn, "Bill"))
+
+
+    # this one is mostly to demostrate how to use this
+    def test_get_all(self):
+        recurring_txns = RecurringTransaction.all(qb=self.qb_client)
+
+        self.assertGreater(len(recurring_txns), 1)
+
+        types = set()
+
+        for recurring_txn in recurring_txns:
+            if hasattr(recurring_txn, "Invoice"):
+                types.add("Invoice")
+            elif hasattr(recurring_txn, "Bill"):
+                types.add("Bill")
+            elif hasattr(recurring_txn, "Purchase"):
+                types.add("Purchase")
+            # etc...
+
+        self.assertIn("Bill", types)
+        self.assertIn("Invoice", types)
+
+    
+    def test_delete_recurring_invoice(self):
+        # add a second to not conflict with the other test
+        saved = self.create_recurring_invoice(self.now + timedelta(seconds=+1))
+        recurring_txn = RecurringTransaction.get(saved.Invoice.Id, qb=self.qb_client)
+
+        recurring_txn.delete(qb=self.qb_client)
+
+

--- a/tests/unit/objects/test_recurringtransaction.py
+++ b/tests/unit/objects/test_recurringtransaction.py
@@ -1,0 +1,12 @@
+import unittest
+
+from quickbooks import QuickBooks
+from quickbooks.objects.recurringtransaction import RecurringTransaction
+
+class RecurringTransactionTests(unittest.TestCase):
+    def test_valid_object_name(self):
+        obj = RecurringTransaction()
+        client = QuickBooks()
+        result = client.isvalid_object_name(obj.qbo_object_name)
+
+        self.assertTrue(result)

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -19,6 +19,7 @@ from quickbooks.objects.base import PhoneNumber, QuickbooksBaseObject
 from quickbooks.objects.department import Department
 from quickbooks.objects.customer import Customer
 from quickbooks.objects.journalentry import JournalEntry, JournalEntryLine
+from quickbooks.objects.recurringtransaction import RecurringTransaction
 from quickbooks.objects.salesreceipt import SalesReceipt
 from quickbooks.mixins import ObjectListMixin
 
@@ -343,6 +344,16 @@ class DeleteMixinTest(QuickbooksUnitTestCase):
         bill = Bill()
         bill.Id = 1
         bill.delete(qb=self.qb_client)
+
+        self.assertTrue(delete_object.called)
+
+
+class DeleteNoIdMixinTest(QuickbooksUnitTestCase):
+    @patch('quickbooks.mixins.QuickBooks.delete_object')
+    def test_delete(self, delete_object):
+        recurring_txn = RecurringTransaction()
+        recurring_txn.Bill = Bill()
+        recurring_txn.delete(qb=self.qb_client)
 
         self.assertTrue(delete_object.called)
 


### PR DESCRIPTION
The RecurringTransaction object in the QBO api is quick awkward to work with. I had to extend each support object and then inject the recurring properties into it. The code for this object is quite a bit different from how other objects work, but at the end of the day you can interact with it using the same patterns as other objects.

I'm happy to discuss further or make changes

Closes: #270 