### PR TITLE
Use with to open file attachments

### DIFF
--- a/quickbooks/client.py
+++ b/quickbooks/client.py
@@ -162,7 +162,6 @@ class QuickBooks(object):
         }
 
         if file_path:
-            attachment = open(file_path, 'rb')
             url = url.replace('attachable', 'upload')
             boundary = '-------------PythonMultipartPost'
             headers.update({
@@ -173,7 +172,8 @@ class QuickBooks(object):
                 'Connection': 'close'
             })
 
-            binary_data = str(base64.b64encode(attachment.read()).decode('ascii'))
+            with open(file_path, 'rb') as attachment:
+                binary_data = str(base64.b64encode(attachment.read()).decode('ascii'))
 
             content_type = json.loads(request_body)['ContentType']
 


### PR DESCRIPTION
Ensures that the file is closed even if there are errors in the process. I discovered this issue because I got a non-200 response that caused the client to raise error code 10000, and my subsequent cleanup code failed to delete a temp file because it was already open.