### PR TITLE
Add 3.12 to setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=find_packages(exclude=("tests",)),
 )


### PR DESCRIPTION
The package installs and runs well on 3.12, let's add it to the distutils classifiers.