### PR TITLE
handle Decimal on amount values

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/quickbooks/mixins.py
+++ b/quickbooks/mixins.py
@@ -7,10 +7,10 @@ from .exceptions import QuickbooksException
 from .utils import build_choose_clause, build_where_clause
 
 class DecimalEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, decimal.Decimal):
-            return str(obj)
-        return super(DecimalEncoder, self).default(obj)
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return str(o)
+        return super(DecimalEncoder, self).default(o)
 
 class ToJsonMixin(object):
     def to_json(self):
@@ -21,7 +21,7 @@ class ToJsonMixin(object):
         filter out properties that have names starting with _
         or properties that have a value of None
         """
-        return lambda obj: dict((k, v) for k, v in obj.__dict__.items()
+        return lambda obj: str(obj) if isinstance(obj, decimal.Decimal) else dict((k, v) for k, v in obj.__dict__.items()
                                 if not k.startswith('_') and getattr(obj, k) is not None)
 
 

--- a/tests/unit/test_decimal.py
+++ b/tests/unit/test_decimal.py
@@ -1,0 +1,21 @@
+from decimal import Decimal
+import unittest
+from quickbooks.objects.bill import Bill
+from quickbooks.objects.detailline import DetailLine
+
+
+class DecimalTestCase(unittest.TestCase):
+    def test_bill_with_decimal_amount(self):
+        """Test that a Bill with decimal line amounts can be converted to JSON without errors"""
+        bill = Bill()
+        line = DetailLine()
+        line.Amount = Decimal('42.42')
+        line.DetailType = "AccountBasedExpenseLineDetail"
+        
+        bill.Line.append(line)
+        
+        # This should not raise any exceptions
+        json_data = bill.to_json()
+        
+        # Verify the amount was converted correctly
+        self.assertIn('"Amount": "42.42"', json_data)


### PR DESCRIPTION
In the testing on my project the jsonEncoder in newer versions of python calls default for both keys and values. This means that you get an exception if you pass in Decimal as a line amount on newer versions of python with the existing lambda on default.

I think we should also include a test where a bill is created with a decimal line amount and to_json() is called to ensure there is no exception. 