### PR TITLE
Fix incompatibility issue with setuptools >= 78

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-description-file = README.md
-
 [flake8]
 max-line-length = 100
 max-complexity = 10


### PR DESCRIPTION
Setuptools deprecated dash-separated settings

From [NEWS.rst](https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7800): 

> Setuptools no longer accepts options containing uppercase or dash characters in setup.cfg. Please ensure to write the options in setup.cfg using the :wiki:`lower_snake_case <Snake_case>` convention (e.g. Name => name, install-requires => install_requires). This is a follow-up on deprecations introduced in v54.1.0 (see #1608) and v54.1.1 (see #2592).

### Issue
```
      setuptools.errors.InvalidConfigError: Invalid dash-separated key
      'description-file' in 'metadata' (setup.cfg), please use the underscore
      name 'description_file' instead.
```

### Solution
~Rename `description-file` to `description_file`~
Remove description-file because it is not supported by setuptools https://github.com/pypa/setuptools/issues/4913

Closes #383 